### PR TITLE
added a fix for the ASG terraform issues, plus fixed the launch configuration aws-cli region issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,14 +18,17 @@ data "aws_ami" "zookeeper" {
   most_recent = true
   name_regex  = "^${var.prefix}${var.name}-.*-\\(\\d{14}\\)$"
   owners      = ["self"]
+
   filter {
     name   = "architecture"
     values = ["x86_64"]
   }
+
   filter {
     name   = "name"
     values = ["${var.ami_prefix}${var.ami_name}-*"]
   }
+
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
@@ -45,24 +48,29 @@ resource "aws_instance" "zookeeper" {
   subnet_id                   = "${element(var.subnet_ids, count.index)}"
   user_data                   = "${element(data.template_file.zookeeper.*.rendered, count.index)}"
   vpc_security_group_ids      = ["${aws_security_group.zookeeper.id}","${aws_security_group.zookeeper_intra.id}","${var.extra_security_group_id}"]
+
   root_block_device {
     volume_size = "${var.root_volume_size}"
     volume_type = "${var.root_volume_type}"
     iops        = "${var.root_volume_iops}"
   }
+
   tags {
-    Name      = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
-    Zookeeper = "true"
-    Service   = "Zookeeper"
+    Name        = "${var.stack}-${var.environment}-${var.prefix}${var.name}-${format("%02d", count.index + 1)}"
+    Zookeeper   = "true"
+    Service     = "Zookeeper"
+    Stack       = "${var.stack}"
+    Environment = "${var.environment}"
   }
 }
 
 data "template_file" "zookeeper" {
   count    = "${var.use_asg ? 0 : var.number_of_instances}"
   template = "${file("${path.module}/templates/cloud-config/init.tpl")}"
+
   vars {
     domain         = "${var.domain}"
-    hostname       = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
+    hostname       = "${var.prefix}${var.name}-${format("%02d", count.index + 1)}"
     zookeeper_args = "-i ${count.index + 1} -n ${join(",", data.template_file.zookeeper_id.*.rendered)} ${var.heap_size == "" ? var.heap_size : "-m var.heap_size"}"
   }
 }
@@ -70,9 +78,10 @@ data "template_file" "zookeeper" {
 data "template_file" "zookeeper_id" {
   count    = "${var.number_of_instances}"
   template = "$${index}:$${hostname}.$${domain}"
+
   vars {
     domain   = "${var.domain}"
-    hostname = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
+    hostname = "${var.prefix}${var.name}-${format("%02d", count.index + 1)}"
     index    = "${count.index + 1}"
   }
 }
@@ -89,38 +98,55 @@ resource "aws_autoscaling_group" "zookeeper" {
   launch_configuration      = "${aws_launch_configuration.zookeeper.name}"
   max_size                  = "${var.number_of_instances}"
   min_size                  = "${var.number_of_instances}"
-  name                      = "${var.prefix}${var.name}"
-  vpc_zone_identifier       = "${slice(var.subnet_ids, 0, var.number_of_instances)}"
+  name                      = "${var.stack}-${var.environment}-${var.prefix}${var.name}"
+  vpc_zone_identifier       = ["${slice(var.subnet_ids, 0, var.number_of_instances)}"]
+
   lifecycle {
     create_before_destroy = true
   }
+
   tag {
     key                 = "Name"
-    value               = "${var.prefix}${var.name}"
+    value               = "${var.stack}-${var.environment}-${var.prefix}${var.name}"
     propagate_at_launch = true
   }
+
   tag {
     key                 = "Zookeeper"
     value               = "true"
     propagate_at_launch = true
   }
+
   tag {
     key                 = "Service"
     value               = "Zookeeper"
     propagate_at_launch = true
   }
+
+  tag {
+    key                 = "Stack"
+    value               = "${var.stack}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.environment}"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_launch_configuration" "zookeeper" {
-  count    = "${var.use_asg ? 1 : 0}"
+  count                       = "${var.use_asg ? 1 : 0}"
   associate_public_ip_address = false
   iam_instance_profile        = "${aws_iam_instance_profile.zookeeper_eni.arn}"
   image_id                    = "${data.aws_ami.zookeeper.id}"
   instance_type               = "${var.instance_type}"
   key_name                    = "${var.keyname}"
-  name_prefix                 = "${var.prefix}${var.name}-"
+  name_prefix                 = "${var.stack}-${var.environment}-${var.prefix}${var.name}-"
   security_groups             = ["${aws_security_group.zookeeper.id}","${aws_security_group.zookeeper_intra.id}","${var.extra_security_group_id}"]
-  user_data = "${data.template_file.zookeeper_asg.rendered}"
+  user_data                   = "${data.template_file.zookeeper_asg.rendered}"
+
   lifecycle {
     create_before_destroy = true
   }
@@ -129,10 +155,11 @@ resource "aws_launch_configuration" "zookeeper" {
 data "template_file" "zookeeper_asg" {
   count    = "${var.use_asg ? 1 : 0}"
   template = "${file("${path.module}/templates/cloud-config/init_asg.tpl")}"
+
   vars {
     domain         = "${var.domain}"
-    eni_reference  = "${var.prefix}${var.name}"
     hostname       = "${var.prefix}${var.name}"
+    eni_reference  = "${var.stack}-${var.environment}-${var.prefix}${var.name}"
     zookeeper_addr = "${join(",", data.template_file.zookeeper_asg_addr.*.rendered)}"
     zookeeper_args = "-n ${join(",", data.template_file.zookeeper_id.*.rendered)} ${var.heap_size == "" ? var.heap_size : "-m var.heap_size"}"
   }
@@ -141,6 +168,7 @@ data "template_file" "zookeeper_asg" {
 data "template_file" "zookeeper_asg_addr" {
   count    = "${var.use_asg ? var.number_of_instances : 0}"
   template = "$${index}:$${address}"
+
   vars {
     address = "${element(split(",", replace(replace(replace(format("%s", aws_network_interface.zookeeper.*.private_ips), "/[^\\s\\d\\.]/", ""), "/(\\d)\\s+/", "$1,"), "/\\s+/", "")), count.index)}"
     index   = "${count.index + 1}"
@@ -152,12 +180,12 @@ data "template_file" "zookeeper_asg_addr" {
 #
 
 resource "aws_iam_instance_profile" "zookeeper_eni" {
-  name  = "${var.prefix}${var.name}-zookeeper-eni"
+  name  = "${var.stack}-${var.environment}-${var.prefix}${var.name}-zookeeper-eni"
   roles = ["${aws_iam_role.zookeeper_eni.id}"]
 }
 
 resource "aws_iam_role" "zookeeper_eni" {
-  name               = "${var.prefix}${var.name}-zookeeper-eni"
+  name               = "${var.stack}-${var.environment}-${var.prefix}${var.name}-zookeeper-eni"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -176,8 +204,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "zookeeper_eni" {
-  name  = "${var.prefix}${var.name}-zookeeper-eni"
-  role = "${aws_iam_role.zookeeper_eni.id}"
+  name   = "${var.stack}-${var.environment}-${var.prefix}${var.name}-zookeeper-eni"
+  role   = "${aws_iam_role.zookeeper_eni.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -210,11 +238,13 @@ resource "aws_network_interface" "zookeeper" {
   subnet_id         = "${element(var.subnet_ids, count.index)}"
   security_groups   = ["${aws_security_group.zookeeper.id}","${aws_security_group.zookeeper_intra.id}","${var.extra_security_group_id}"]
   source_dest_check = false
+
   tags {
-    Name      = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
-    Reference = "${var.prefix}${var.name}"
-    Zookeeper = "true"
-    Service   = "Zookeeper"
+    Zookeeper   = "true"
+    Service     = "Zookeeper"
+    Reference   = "${var.stack}-${var.environment}-${var.prefix}${var.name}"
+    Stack       = "${var.stack}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -231,8 +261,8 @@ resource "aws_eip" "zookeeper" {
 
 resource "aws_route53_record" "private" {
   count   = "${var.private_zone_id != "" ? var.number_of_instances : 0}"
-  name    = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
-  records = ["${var.use_asg ? element(split(",", replace(replace(replace(format("%s", aws_network_interface.zookeeper.*.private_ips), "/[^\\s\\d\\.]/", ""), "/(\\d)\\s+/", "$1,"), "/\\s+/", "")), count.index) : element(aws_instance.zookeeper.*.private_ip, count.index)}"]
+  name    = "${var.prefix}${var.name}-${format("%02d", count.index + 1)}"
+  records = ["${var.use_asg ? element(split(",", replace(replace(replace(format("%s", aws_network_interface.zookeeper.*.private_ips), "/[^\\s\\d\\.]/", ""), "/(\\d)\\s+/", "$1,"), "/\\s+/", "")), count.index) : element(concat(aws_instance.zookeeper.*.private_ip, list("")), count.index)}"]
   ttl     = "${var.ttl}"
   type    = "A"
   zone_id = "${var.private_zone_id}"
@@ -240,8 +270,8 @@ resource "aws_route53_record" "private" {
 
 resource "aws_route53_record" "public" {
   count   = "${var.public_zone_id != "" && var.associate_public_ip_address ? var.number_of_instances : 0}"
-  name    = "${var.prefix}${var.name}${format("%02d", count.index + 1)}"
-  records = ["${var.use_asg ? element(aws_eip.zookeeper.*.public_ip, count.index) : element(aws_instance.zookeeper.*.public_ip, count.index)}"]
+  name    = "${var.prefix}${var.name}-${format("%02d", count.index + 1)}"
+  records = ["${var.use_asg ? element(aws_eip.zookeeper.*.public_ip, count.index) : element(concat(aws_instance.zookeeper.*.public_ip, list("")), count.index)}"]
   ttl     = "${var.ttl}"
   type    = "A"
   zone_id = "${var.public_zone_id}"
@@ -252,70 +282,87 @@ resource "aws_route53_record" "public" {
 #
 
 resource "aws_security_group" "zookeeper" {
-  name   = "${var.prefix}${var.name}"
+  name   = "${var.stack}-${var.environment}-${var.prefix}${var.name}-${var.environment}"
   vpc_id = "${var.vpc_id}"
+
   ingress {
     from_port = 2181
     to_port   = 2181
     protocol  = "tcp"
     self      = true
   }
+
   lifecycle {
     create_before_destroy = true
   }
+
   tags {
-    Name      = "${var.prefix}${var.name}"
-    Zookeeper = "true"
-    Service   = "Zookeeper"
+    Name        = "${var.stack}-${var.environment}-${var.prefix}${var.name}-${var.environment}"
+    Zookeeper   = "true"
+    Service     = "Zookeeper"
+    Stack       = "${var.stack}"
+    Environment = "${var.environment}"
   }
 }
 
 resource "aws_security_group" "zookeeper_intra" {
-  name   = "${var.prefix}${var.name}-intra"
+  name   = "${var.stack}-${var.environment}-${var.prefix}${var.name}-intra"
   vpc_id = "${var.vpc_id}"
+
   ingress {
     from_port = 2888
     to_port   = 2888
     protocol  = "tcp"
     self      = true
   }
+
   ingress {
     from_port = 3888
     to_port   = 3888
     protocol  = "tcp"
     self      = true
   }
+
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   lifecycle {
     create_before_destroy = true
   }
+
   tags {
-    Name      = "${var.prefix}${var.name}-intra"
-    Zookeeper = "true"
-    Service   = "Zookeeper"
+    Name        = "${var.stack}-${var.environment}-${var.prefix}${var.name}-intra"
+    Zookeeper   = "true"
+    Service     = "Zookeeper"
+    Stack       = "${var.stack}"
+    Environment = "${var.environment}"
   }
 }
 
 resource "aws_security_group" "zookeeper_monit" {
-  name   = "${var.prefix}${var.name}-monit"
+  name   = "${var.stack}-${var.environment}-${var.prefix}${var.name}-monit"
   vpc_id = "${var.vpc_id}"
+
   ingress {
     from_port = 7199
     to_port   = 7199
     protocol  = "tcp"
     self      = true
   }
+
   lifecycle {
     create_before_destroy = true
   }
+
   tags {
-    Name      = "${var.prefix}${var.name}-monit"
-    Zookeeper = "true"
-    Service   = "Zookeeper"
+    Name        = "${var.stack}-${var.environment}-${var.prefix}${var.name}-monit"
+    Zookeeper   = "true"
+    Service     = "Zookeeper"
+    Stack       = "${var.stack}"
+    Environment = "${var.environment}"
   }
 }

--- a/templates/cloud-config/init_asg.tpl
+++ b/templates/cloud-config/init_asg.tpl
@@ -16,8 +16,10 @@ manage_etc_hosts: true
 write_files:
   - content: |
       #!/bin/bash
-      echo "=== Setting Variables ==="
       __AWS_METADATA_ADDR__="169.254.169.254"
+      echo "=== Configuring aws-cli ==="
+      aws configure set region $(curl http://$${__AWS_METADATA_ADDR__}/latest/dynamic/instance-identity/document|grep region|awk -F\" '{print $4}')
+      echo "=== Setting Variables ==="
       __MAC_ADDRESS__="$$(curl -s http://$${__AWS_METADATA_ADDR__}/latest/meta-data/network/interfaces/macs/ | awk '{print $$1}')"
       __INSTANCE_ID__=$$(curl -s http://$${__AWS_METADATA_ADDR__}/latest/meta-data/instance-id)
       __SUBNET_ID__="$$(curl -s http://$${__AWS_METADATA_ADDR__}/latest/meta-data/network/interfaces/macs/$${__MAC_ADDRESS__}subnet-id)"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,16 @@
 # terms of the MIT License.
 #
 
+variable "stack" {
+  description = "The name of the stack the cluster belongs to, only used for cost allocation tracking"
+  type        = "string"
+}
+
+variable "environment" {
+  description = "The name of the environment the cluster belongs to, only used for cost allocation tracking"
+  type        = "string"
+}
+
 variable "ami_name" {
   description = "The name of the AMI to use for the instance(s)."
   default     = "zookeeper"


### PR DESCRIPTION
This PR:
- fixes the terraform ternary operator issues
- fixes launch configuration user data script bug (missing region for the `aws-cli`)
- adds `Stack` and `Environment` tags to all resources for cost allocation tracking
- adds `stack-environment-` prefix to all resources to avoid collisions when creating multiple clusters in one AWS account 
- fixes formatting

ping @gkocur 